### PR TITLE
Note-detecting improvement for intake

### DIFF
--- a/src/main/java/org/sciborgs1155/robot/Robot.java
+++ b/src/main/java/org/sciborgs1155/robot/Robot.java
@@ -58,9 +58,9 @@ public class Robot extends CommandRobot implements Logged {
   private final CommandXboxController operator = new CommandXboxController(OI.OPERATOR);
   private final CommandXboxController driver = new CommandXboxController(OI.DRIVER);
 
-  private boolean noteDetectected = false;
+  @Log.NT private boolean noteDetected = false;
   private EventLoop intakeTriggerPoller = new EventLoop();
-  private Trigger intakeTrigger = new Trigger(intakeTriggerPoller, () -> noteDetectected);
+  private Trigger intakeTrigger = new Trigger(intakeTriggerPoller, () -> noteDetected);
 
   // SUBSYSTEMS
   private final Drive drive = Drive.create();
@@ -68,7 +68,7 @@ public class Robot extends CommandRobot implements Logged {
   private final Intake intake =
       switch (Constants.ROBOT_TYPE) {
         case CHASSIS -> Intake.none();
-        default -> Intake.create((b) -> noteDetectected = b);
+        default -> Intake.create((b) -> noteDetected = b);
       };
 
   private final Shooter shooter =

--- a/src/main/java/org/sciborgs1155/robot/intake/Intake.java
+++ b/src/main/java/org/sciborgs1155/robot/intake/Intake.java
@@ -1,13 +1,11 @@
 package org.sciborgs1155.robot.intake;
 
 import static edu.wpi.first.units.Units.Seconds;
-import static edu.wpi.first.units.Units.Amps;
 import static org.sciborgs1155.robot.intake.IntakeConstants.DEBOUNCE_TIME;
-import static org.sciborgs1155.robot.intake.IntakeConstants.NOTE_INVASION_INDICATOR_OOGA_BOOGA;
 
 import edu.wpi.first.math.filter.Debouncer.DebounceType;
 import edu.wpi.first.math.system.plant.DCMotor;
-import edu.wpi.first.wpilibj.event.EventLoop;
+import edu.wpi.first.util.function.BooleanConsumer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -19,8 +17,8 @@ import org.sciborgs1155.robot.Robot;
 import org.sciborgs1155.robot.commands.NoteVisualizer;
 
 public class Intake extends SubsystemBase implements Logged, AutoCloseable {
-  public static Intake create() {
-    return Robot.isReal() ? new Intake(new RealIntake()) : new Intake(new NoIntake());
+  public static Intake create(BooleanConsumer observer) {
+    return Robot.isReal() ? new Intake(new RealIntake(observer)) : new Intake(new NoIntake());
   }
 
   public static Intake none() {
@@ -28,10 +26,8 @@ public class Intake extends SubsystemBase implements Logged, AutoCloseable {
   }
 
   private final IntakeIO hardware;
-  private final EventLoop currentSpikePoller;
 
   public Intake(IntakeIO hardware) {
-    this.currentSpikePoller = new EventLoop();
     this.hardware = hardware;
   }
 
@@ -82,10 +78,9 @@ public class Intake extends SubsystemBase implements Logged, AutoCloseable {
    * @return A trigger based on the intake beambreak.
    */
   public Trigger hasNote() {
-    // return new Trigger(hardware::beambreak)
-    //     .negate()
-    //     .debounce(DEBOUNCE_TIME.in(Seconds), DebounceType.kFalling);
-    return new Trigger(currentSpikePoller, () -> hardware.current() > NOTE_INVASION_INDICATOR_OOGA_BOOGA.in(Amps));
+    return new Trigger(hardware::beambreak)
+        .negate()
+        .debounce(DEBOUNCE_TIME.in(Seconds), DebounceType.kFalling);
   }
 
   @Log.NT

--- a/src/main/java/org/sciborgs1155/robot/intake/Intake.java
+++ b/src/main/java/org/sciborgs1155/robot/intake/Intake.java
@@ -1,10 +1,13 @@
 package org.sciborgs1155.robot.intake;
 
 import static edu.wpi.first.units.Units.Seconds;
+import static edu.wpi.first.units.Units.Amps;
 import static org.sciborgs1155.robot.intake.IntakeConstants.DEBOUNCE_TIME;
+import static org.sciborgs1155.robot.intake.IntakeConstants.NOTE_INVASION_INDICATOR_OOGA_BOOGA;
 
 import edu.wpi.first.math.filter.Debouncer.DebounceType;
 import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.event.EventLoop;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -25,8 +28,10 @@ public class Intake extends SubsystemBase implements Logged, AutoCloseable {
   }
 
   private final IntakeIO hardware;
+  private final EventLoop currentSpikePoller;
 
   public Intake(IntakeIO hardware) {
+    this.currentSpikePoller = new EventLoop();
     this.hardware = hardware;
   }
 
@@ -77,9 +82,10 @@ public class Intake extends SubsystemBase implements Logged, AutoCloseable {
    * @return A trigger based on the intake beambreak.
    */
   public Trigger hasNote() {
-    return new Trigger(hardware::beambreak)
-        .negate()
-        .debounce(DEBOUNCE_TIME.in(Seconds), DebounceType.kFalling);
+    // return new Trigger(hardware::beambreak)
+    //     .negate()
+    //     .debounce(DEBOUNCE_TIME.in(Seconds), DebounceType.kFalling);
+    return new Trigger(currentSpikePoller, () -> hardware.current() > NOTE_INVASION_INDICATOR_OOGA_BOOGA.in(Amps));
   }
 
   @Log.NT

--- a/src/main/java/org/sciborgs1155/robot/intake/IntakeConstants.java
+++ b/src/main/java/org/sciborgs1155/robot/intake/IntakeConstants.java
@@ -13,5 +13,4 @@ public final class IntakeConstants {
   public static final Measure<Time> DEBOUNCE_TIME = Seconds.of(0);
 
   public static final Measure<Current> STALL_THRESHOLD = Amps.of(40);
-  public static final Measure<Current> NOTE_INVASION_INDICATOR_OOGA_BOOGA = Amps.of(0); //TODO
 }

--- a/src/main/java/org/sciborgs1155/robot/intake/IntakeConstants.java
+++ b/src/main/java/org/sciborgs1155/robot/intake/IntakeConstants.java
@@ -11,6 +11,7 @@ public final class IntakeConstants {
   public static final Measure<Current> CURRENT_LIMIT = Amps.of(50);
   public static final Measure<Time> RAMP_TIME = Milliseconds.of(50);
   public static final Measure<Time> DEBOUNCE_TIME = Seconds.of(0);
+  public static final Measure<Time> INTAKE_FAST_PERIOD = Milliseconds.of(5);
 
   public static final Measure<Current> STALL_THRESHOLD = Amps.of(40);
 }

--- a/src/main/java/org/sciborgs1155/robot/intake/IntakeConstants.java
+++ b/src/main/java/org/sciborgs1155/robot/intake/IntakeConstants.java
@@ -13,4 +13,5 @@ public final class IntakeConstants {
   public static final Measure<Time> DEBOUNCE_TIME = Seconds.of(0);
 
   public static final Measure<Current> STALL_THRESHOLD = Amps.of(40);
+  public static final Measure<Current> NOTE_INVASION_INDICATOR_OOGA_BOOGA = Amps.of(0); //TODO
 }

--- a/src/main/java/org/sciborgs1155/robot/intake/IntakeIO.java
+++ b/src/main/java/org/sciborgs1155/robot/intake/IntakeIO.java
@@ -8,4 +8,6 @@ public interface IntakeIO extends AutoCloseable, Logged {
   boolean beambreak();
 
   double current();
+
+  boolean seenNote();
 }

--- a/src/main/java/org/sciborgs1155/robot/intake/NoIntake.java
+++ b/src/main/java/org/sciborgs1155/robot/intake/NoIntake.java
@@ -16,4 +16,9 @@ public class NoIntake implements IntakeIO {
   public double current() {
     return 0;
   }
+
+  @Override
+  public boolean seenNote() {
+    return false;
+  }
 }

--- a/src/main/java/org/sciborgs1155/robot/intake/RealIntake.java
+++ b/src/main/java/org/sciborgs1155/robot/intake/RealIntake.java
@@ -7,7 +7,6 @@ import static org.sciborgs1155.robot.intake.IntakeConstants.*;
 import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkFlex;
 import com.revrobotics.CANSparkLowLevel.MotorType;
-import edu.wpi.first.util.function.BooleanConsumer;
 import edu.wpi.first.wpilibj.AsynchronousInterrupt;
 import edu.wpi.first.wpilibj.DigitalInput;
 import monologue.Annotations.Log;
@@ -20,8 +19,9 @@ public class RealIntake implements IntakeIO {
 
   private final DigitalInput beambreak = new DigitalInput(Ports.Intake.BEAMBREAK);
   private final AsynchronousInterrupt asyncInterrupt;
+  private boolean noteDetected = false;
 
-  public RealIntake(BooleanConsumer observer) {
+  public RealIntake() {
     check(spark, spark.restoreFactoryDefaults());
     check(spark, SparkUtils.configureNothingFrameStrategy(spark));
     spark.setInverted(true);
@@ -38,9 +38,9 @@ public class RealIntake implements IntakeIO {
             beambreak,
             (Boolean rising, Boolean falling) -> {
               if (falling) {
-                observer.accept(true);
+                noteDetected = true;
               } else if (rising) {
-                observer.accept(false);
+                noteDetected = false;
               }
             });
 
@@ -70,5 +70,11 @@ public class RealIntake implements IntakeIO {
   public void close() {
     beambreak.close();
     spark.close();
+  }
+
+  @Override
+  @Log.NT
+  public boolean seenNote() {
+    return noteDetected;
   }
 }

--- a/src/main/java/org/sciborgs1155/robot/intake/RealIntake.java
+++ b/src/main/java/org/sciborgs1155/robot/intake/RealIntake.java
@@ -9,6 +9,8 @@ import com.revrobotics.CANSparkFlex;
 import com.revrobotics.CANSparkLowLevel.MotorType;
 import edu.wpi.first.wpilibj.DigitalInput;
 import monologue.Annotations.Log;
+
+import org.sciborgs1155.lib.InputStream;
 import org.sciborgs1155.lib.SparkUtils;
 import org.sciborgs1155.robot.Ports;
 

--- a/src/test/java/org/sciborgs1155/robot/IntakeTest.java
+++ b/src/test/java/org/sciborgs1155/robot/IntakeTest.java
@@ -7,7 +7,7 @@ import org.sciborgs1155.robot.intake.Intake;
 public class IntakeTest {
   @Test
   public void init() throws Exception {
-    Intake.create().close();
+    Intake.create((b) -> {}).close();
     TestingUtil.reset();
   }
 }

--- a/src/test/java/org/sciborgs1155/robot/IntakeTest.java
+++ b/src/test/java/org/sciborgs1155/robot/IntakeTest.java
@@ -7,7 +7,7 @@ import org.sciborgs1155.robot.intake.Intake;
 public class IntakeTest {
   @Test
   public void init() throws Exception {
-    Intake.create((b) -> {}).close();
+    Intake.create().close();
     TestingUtil.reset();
   }
 }


### PR DESCRIPTION
Resolves #69 
This adds two new features:
  1. Polling is now at a 5ms period as opposed to the standard 20ms (for beambreak trigger)
  2. An AsynchronousInterrupted class is used to ensure that a falling edge + rising edge that occurs between polls doesn't get missed