### PR TITLE
Fast odometry (fast)

### DIFF
--- a/src/main/java/org/sciborgs1155/lib/SparkUtils.java
+++ b/src/main/java/org/sciborgs1155/lib/SparkUtils.java
@@ -32,6 +32,7 @@ public class SparkUtils {
   public static final int FRAME_STRATEGY_MEDIUM = 100;
   public static final int FRAME_STRATEGY_FAST = 20;
   public static final int FRAME_STRATEGY_VERY_FAST = 10;
+  public static final int FRAME_STRATEGY_VERY_VERY_FAST = 4;
 
   public static final int THROUGHBORE_CPR = 8192;
 
@@ -112,7 +113,7 @@ public class SparkUtils {
     }
 
     if (sensors.contains(Sensor.INTEGRATED) && data.contains(Data.POSITION)) {
-      status2 = FRAME_STRATEGY_FAST;
+      status2 = FRAME_STRATEGY_VERY_VERY_FAST; // TODO change after onboarding
       supplier2 = Optional.of(() -> spark.getEncoder().getPosition());
     }
 
@@ -131,7 +132,7 @@ public class SparkUtils {
 
     if (sensors.contains(Sensor.ABSOLUTE)) {
       if (data.contains(Data.POSITION)) {
-        status5 = FRAME_STRATEGY_FAST;
+        status5 = FRAME_STRATEGY_VERY_VERY_FAST; // TODO this too
         supplier5 = Optional.of(() -> spark.getAbsoluteEncoder().getPosition());
       }
       if (data.contains(Data.VELOCITY)) {

--- a/src/main/java/org/sciborgs1155/robot/Constants.java
+++ b/src/main/java/org/sciborgs1155/robot/Constants.java
@@ -53,6 +53,7 @@ public class Constants {
   }
 
   public static final Measure<Time> PERIOD = Seconds.of(0.02); // roborio tickrate (s)
+  public static final Measure<Time> ODOMETRY_PERIOD = Seconds.of(1.0 / 250.0);
   public static final double DEADBAND = 0.15;
   public static final double MAX_RATE =
       DriveConstants.MAX_ACCEL.baseUnitMagnitude()

--- a/src/main/java/org/sciborgs1155/robot/Robot.java
+++ b/src/main/java/org/sciborgs1155/robot/Robot.java
@@ -120,7 +120,7 @@ public class Robot extends CommandRobot implements Logged {
     // SmartDashboard.putData("PDH", new PowerDistribution());
     addPeriodic(() -> log("current", FakePDH.update()), PERIOD.in(Seconds));
 
-    // Configure pose estimation updates every tick
+    // Configure pose estimation updates from vision every tick
     addPeriodic(() -> drive.updateEstimates(vision.getEstimatedGlobalPoses()), PERIOD.in(Seconds));
 
     // Fuck REV Robotics.!!!!

--- a/src/main/java/org/sciborgs1155/robot/drive/Drive.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/Drive.java
@@ -71,7 +71,7 @@ public class Drive extends SubsystemBase implements Logged, AutoCloseable {
 
   // Odometry and pose estimation
   private final SwerveDrivePoseEstimator odometry;
-  private SwerveModulePosition[] lastModulePositions = getModulePositions();
+  private SwerveModulePosition[] lastModulePositions;
   public static final ReadWriteLock lock = new ReentrantReadWriteLock();
 
   @Log.NT private final Field2d field2d = new Field2d();
@@ -124,6 +124,7 @@ public class Drive extends SubsystemBase implements Logged, AutoCloseable {
 
     modules = List.of(this.frontLeft, this.frontRight, this.rearLeft, this.rearRight);
     modules2d = new FieldObject2d[modules.size()];
+    lastModulePositions = getModulePositions();
 
     translationCharacterization =
         new SysIdRoutine(
@@ -170,6 +171,9 @@ public class Drive extends SubsystemBase implements Logged, AutoCloseable {
     translationController.setTolerance(Translation.TOLERANCE.in(Meters));
     rotationController.enableContinuousInput(0, 2 * Math.PI);
     rotationController.setTolerance(Rotation.TOLERANCE.in(Radians));
+
+    SparkOdometryThread.getInstance().start();
+    TalonOdometryThread.getInstance().start();
 
     SmartDashboard.putData(
         "translation quasistatic forward",

--- a/src/main/java/org/sciborgs1155/robot/drive/Drive.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/Drive.java
@@ -386,7 +386,16 @@ public class Drive extends SubsystemBase implements Logged, AutoCloseable {
 
   @Override
   public void periodic() {
-    odometry.update(Robot.isReal() ? gyro.getRotation2d() : simRotation, getModulePositions());
+    double[] timestamps = modules.get(0).timestamps();
+    // get the positions of all modules at a given timestamp
+    for (int i = 0; i < timestamps.length; i++) {
+      SwerveModulePosition[] modulePositions = new SwerveModulePosition[4];
+      for (int m = 0; m < modules.size(); m++) {
+        modulePositions[m] = modules.get(m).odometryData()[i];
+      }
+      odometry.updateWithTime(
+          timestamps[i], Robot.isReal() ? gyro.getRotation2d() : simRotation, modulePositions);
+    }
 
     field2d.setRobotPose(pose());
 

--- a/src/main/java/org/sciborgs1155/robot/drive/ModuleIO.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/ModuleIO.java
@@ -40,7 +40,7 @@ public interface ModuleIO extends AutoCloseable, Logged {
    */
   Rotation2d rotation();
 
-  double[][] odometrySignals();
+  double[][] odometryData();
 
   /** Resets all encoders. */
   void resetEncoders();

--- a/src/main/java/org/sciborgs1155/robot/drive/ModuleIO.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/ModuleIO.java
@@ -40,7 +40,7 @@ public interface ModuleIO extends AutoCloseable, Logged {
    */
   Rotation2d rotation();
 
-  double[] odometryMeasurements();
+  double[][] odometrySignals();
 
   /** Resets all encoders. */
   void resetEncoders();

--- a/src/main/java/org/sciborgs1155/robot/drive/ModuleIO.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/ModuleIO.java
@@ -40,6 +40,8 @@ public interface ModuleIO extends AutoCloseable, Logged {
    */
   Rotation2d rotation();
 
+  double[] odometryMeasurements();
+
   /** Resets all encoders. */
   void resetEncoders();
 

--- a/src/main/java/org/sciborgs1155/robot/drive/NoModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/NoModule.java
@@ -26,8 +26,8 @@ public class NoModule implements ModuleIO {
   }
 
   @Override
-  public double[] odometryMeasurements() {
-    return new double[0];
+  public double[][] odometrySignals() {
+    return new double[0][0];
   }
 
   @Override

--- a/src/main/java/org/sciborgs1155/robot/drive/NoModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/NoModule.java
@@ -26,6 +26,11 @@ public class NoModule implements ModuleIO {
   }
 
   @Override
+  public double[] odometryMeasurements() {
+    return new double[0];
+  }
+
+  @Override
   public void resetEncoders() {}
 
   @Override

--- a/src/main/java/org/sciborgs1155/robot/drive/NoModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/NoModule.java
@@ -26,7 +26,7 @@ public class NoModule implements ModuleIO {
   }
 
   @Override
-  public double[][] odometrySignals() {
+  public double[][] odometryData() {
     return new double[0][0];
   }
 

--- a/src/main/java/org/sciborgs1155/robot/drive/OdometryThread.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/OdometryThread.java
@@ -1,0 +1,56 @@
+package org.sciborgs1155.robot.drive;
+
+import edu.wpi.first.wpilibj.Notifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.DoubleSupplier;
+
+class OdometryThread {
+  private List<DoubleSupplier> signals = new ArrayList<>();
+  private List<Queue<Double>> queues = new ArrayList<>();
+
+  public static final Lock lock = new ReentrantLock();
+
+  private final Notifier notifier;
+
+  private static OdometryThread instance = null;
+
+  public static OdometryThread getInstance() {
+    if (instance == null) {
+      instance = new OdometryThread();
+    }
+    return instance;
+  }
+
+  private OdometryThread() {
+    notifier = new Notifier(this::periodic);
+    notifier.setName("odometry-thread");
+  }
+
+  public void start() {
+    notifier.startPeriodic(1.0 / 250.0);
+  }
+
+  public Queue<Double> registerSignals(DoubleSupplier signal) {
+    Queue<Double> entry = new ArrayBlockingQueue<>(10);
+    lock.lock();
+
+    signals.add(signal);
+    queues.add(entry);
+
+    lock.unlock();
+    return entry;
+  }
+
+  private void periodic() {
+    lock.lock();
+    for (int i = 0; i < signals.size(); i++) {
+      queues.get(i).offer(signals.get(i).getAsDouble());
+    }
+    lock.unlock();
+  }
+}

--- a/src/main/java/org/sciborgs1155/robot/drive/SimModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SimModule.java
@@ -61,7 +61,7 @@ public class SimModule implements ModuleIO {
   public void close() {}
 
   @Override
-  public double[][] odometrySignals() {
+  public double[][] odometryData() {
     // TODO Auto-generated method stub
     throw new UnsupportedOperationException("Unimplemented method 'odometryMeasurements'");
   }

--- a/src/main/java/org/sciborgs1155/robot/drive/SimModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SimModule.java
@@ -61,7 +61,7 @@ public class SimModule implements ModuleIO {
   public void close() {}
 
   @Override
-  public double[] odometryMeasurements() {
+  public double[][] odometrySignals() {
     // TODO Auto-generated method stub
     throw new UnsupportedOperationException("Unimplemented method 'odometryMeasurements'");
   }

--- a/src/main/java/org/sciborgs1155/robot/drive/SimModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SimModule.java
@@ -59,4 +59,10 @@ public class SimModule implements ModuleIO {
 
   @Override
   public void close() {}
+
+  @Override
+  public double[] odometryMeasurements() {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'odometryMeasurements'");
+  }
 }

--- a/src/main/java/org/sciborgs1155/robot/drive/SimModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SimModule.java
@@ -62,7 +62,6 @@ public class SimModule implements ModuleIO {
 
   @Override
   public double[][] odometryData() {
-    // TODO Auto-generated method stub
-    throw new UnsupportedOperationException("Unimplemented method 'odometryMeasurements'");
+    return new double[][] {};
   }
 }

--- a/src/main/java/org/sciborgs1155/robot/drive/SparkModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SparkModule.java
@@ -29,7 +29,7 @@ public class SparkModule implements ModuleIO {
 
   private final Rotation2d angularOffset;
 
-  private final OdometryThread thread;
+  private final SparkOdometryThread thread;
 
   private Queue<Double> position;
   private Queue<Double> velocity;
@@ -99,10 +99,10 @@ public class SparkModule implements ModuleIO {
                     false)));
     check(turnMotor, turnMotor.burnFlash());
 
-    thread = OdometryThread.getInstance();
-    position = thread.registerSignals(this::drivePosition);
-    velocity = thread.registerSignals(this::driveVelocity);
-    rotation = thread.registerSignals(() -> rotation().getRadians());
+    thread = SparkOdometryThread.getInstance();
+    position = thread.registerSignal(this::drivePosition);
+    velocity = thread.registerSignal(this::driveVelocity);
+    rotation = thread.registerSignal(() -> rotation().getRadians());
 
     register(driveMotor);
     register(turnMotor);
@@ -149,14 +149,14 @@ public class SparkModule implements ModuleIO {
   }
 
   @Override
-  public double[][] odometrySignals() {
-    OdometryThread.lock.readLock().lock();
+  public double[][] odometryData() {
+    SparkOdometryThread.lock.readLock().lock();
     double[][] data = {
       position.stream().mapToDouble((Double d) -> d).toArray(),
       velocity.stream().mapToDouble((Double d) -> d).toArray(),
       rotation.stream().mapToDouble((Double d) -> d).toArray()
     };
-    OdometryThread.lock.readLock().unlock();
+    SparkOdometryThread.lock.readLock().unlock();
     return data;
   }
 

--- a/src/main/java/org/sciborgs1155/robot/drive/SparkModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SparkModule.java
@@ -12,6 +12,7 @@ import com.revrobotics.RelativeEncoder;
 import com.revrobotics.SparkAbsoluteEncoder;
 import edu.wpi.first.math.geometry.Rotation2d;
 import java.util.Set;
+import java.util.function.Supplier;
 import org.sciborgs1155.lib.SparkUtils;
 import org.sciborgs1155.lib.SparkUtils.Data;
 import org.sciborgs1155.lib.SparkUtils.Sensor;
@@ -121,6 +122,8 @@ public class SparkModule implements ModuleIO {
 
   @Override
   public double driveVelocity() {
+    // create a supplier for getVelocity() that is registered by OdometryThread, called there, and
+    // then returned in some way to this method
     lastVelocity = SparkUtils.wrapCall(driveMotor, driveEncoder.getVelocity()).orElse(lastVelocity);
     return lastVelocity;
   }
@@ -139,5 +142,14 @@ public class SparkModule implements ModuleIO {
   public void close() {
     driveMotor.close();
     turnMotor.close();
+  }
+
+  @Override
+  public double[] odometryMeasurements() {
+    OdometryThread.lock.lock();
+    Supplier<Double> drivePosition = this::drivePosition;
+    Supplier<Double> driveVelocity = this::driveVelocity;
+    Supplier<Double> rotation = () -> rotation().getRadians();
+    return new double[0];
   }
 }

--- a/src/main/java/org/sciborgs1155/robot/drive/SparkModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SparkModule.java
@@ -150,14 +150,17 @@ public class SparkModule implements ModuleIO {
 
   @Override
   public double[][] odometryData() {
-    SparkOdometryThread.lock.readLock().lock();
-    double[][] data = {
-      position.stream().mapToDouble((Double d) -> d).toArray(),
-      rotation.stream().mapToDouble((Double d) -> d).toArray(),
-      timestamps.stream().mapToDouble((Double d) -> d).toArray()
-    };
-    SparkOdometryThread.lock.readLock().unlock();
-    return data;
+    Drive.lock.readLock().lock();
+    try {
+      double[][] data = {
+        position.stream().mapToDouble((Double d) -> d).toArray(),
+        rotation.stream().mapToDouble((Double d) -> d).toArray(),
+        timestamps.stream().mapToDouble((Double d) -> d).toArray()
+      };
+      return data;
+    } finally {
+      Drive.lock.readLock().unlock();
+    }
   }
 
   @Override

--- a/src/main/java/org/sciborgs1155/robot/drive/SparkModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SparkModule.java
@@ -29,15 +29,15 @@ public class SparkModule implements ModuleIO {
 
   private final Rotation2d angularOffset;
 
-  private final SparkOdometryThread thread;
-
-  private Queue<Double> position;
-  private Queue<Double> velocity;
-  private Queue<Double> rotation;
-
   private double lastPosition;
   private double lastVelocity;
   private Rotation2d lastRotation;
+
+  private final SparkOdometryThread thread;
+
+  private final Queue<Double> position;
+  private final Queue<Double> rotation;
+  private final Queue<Double> timestamps;
 
   /**
    * Constructs a SwerveModule for rev's MAX Swerve.
@@ -101,8 +101,8 @@ public class SparkModule implements ModuleIO {
 
     thread = SparkOdometryThread.getInstance();
     position = thread.registerSignal(this::drivePosition);
-    velocity = thread.registerSignal(this::driveVelocity);
     rotation = thread.registerSignal(() -> rotation().getRadians());
+    timestamps = thread.makeTimestampQueue();
 
     register(driveMotor);
     register(turnMotor);
@@ -153,8 +153,8 @@ public class SparkModule implements ModuleIO {
     SparkOdometryThread.lock.readLock().lock();
     double[][] data = {
       position.stream().mapToDouble((Double d) -> d).toArray(),
-      velocity.stream().mapToDouble((Double d) -> d).toArray(),
-      rotation.stream().mapToDouble((Double d) -> d).toArray()
+      rotation.stream().mapToDouble((Double d) -> d).toArray(),
+      timestamps.stream().mapToDouble((Double d) -> d).toArray()
     };
     SparkOdometryThread.lock.readLock().unlock();
     return data;

--- a/src/main/java/org/sciborgs1155/robot/drive/SparkOdometryThread.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SparkOdometryThread.java
@@ -34,7 +34,7 @@ class SparkOdometryThread {
 
   public void start() {
     if (timestampQueues.size() > 0) {
-      notifier.startPeriodic(1.0 / Constants.ODOMETRY_PERIOD.in(Seconds));
+      notifier.startPeriodic(Constants.ODOMETRY_PERIOD.in(Seconds));
     }
   } // <3 6328
 

--- a/src/main/java/org/sciborgs1155/robot/drive/SparkOdometryThread.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SparkOdometryThread.java
@@ -3,6 +3,7 @@ package org.sciborgs1155.robot.drive;
 import static edu.wpi.first.units.Units.Seconds;
 
 import edu.wpi.first.wpilibj.Notifier;
+import edu.wpi.first.wpilibj.Timer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
@@ -13,8 +14,9 @@ import java.util.function.DoubleSupplier;
 import org.sciborgs1155.robot.Constants;
 
 class SparkOdometryThread {
-  private List<DoubleSupplier> signals = new ArrayList<>();
-  private List<Queue<Double>> queues = new ArrayList<>();
+  private final List<DoubleSupplier> signals = new ArrayList<>();
+  private final List<Queue<Double>> queues = new ArrayList<>();
+  private final List<Queue<Double>> timestampQueues = new ArrayList<>();
   public static final ReadWriteLock lock = new ReentrantReadWriteLock();
 
   private final Notifier notifier;
@@ -34,9 +36,17 @@ class SparkOdometryThread {
   }
 
   public void start() {
-    notifier.startPeriodic(Constants.ODOMETRY_PERIOD.in(Seconds));
-  }
+    if (timestampQueues.size() > 0) {
+      notifier.startPeriodic(1.0 / Constants.ODOMETRY_PERIOD.in(Seconds));
+    }
+  } // <3 6328
 
+  /**
+   * Register a queue that is filled by the polled signal.
+   *
+   * @param signal
+   * @return A queue of doubles that will be populated with signal double values/
+   */
   public Queue<Double> registerSignal(DoubleSupplier signal) {
     Queue<Double> entry = new ArrayBlockingQueue<>(10);
     lock.writeLock().lock();
@@ -48,10 +58,20 @@ class SparkOdometryThread {
     return entry;
   }
 
+  public Queue<Double> makeTimestampQueue() {
+    Queue<Double> queue = new ArrayBlockingQueue<>(20);
+    timestampQueues.add(queue);
+    return queue;
+  }
+
   private void periodic() {
     lock.writeLock().lock();
+    double timestamp = Timer.getFPGATimestamp(); // non-deterministic
     for (int i = 0; i < signals.size(); i++) {
       queues.get(i).offer(signals.get(i).getAsDouble());
+    }
+    for (int i = 0; i < timestampQueues.size(); i++) {
+      timestampQueues.get(i).offer(timestamp);
     }
     lock.writeLock().unlock();
   }

--- a/src/main/java/org/sciborgs1155/robot/drive/SparkOdometryThread.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SparkOdometryThread.java
@@ -8,8 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.DoubleSupplier;
 import org.sciborgs1155.robot.Constants;
 
@@ -17,7 +15,6 @@ class SparkOdometryThread {
   private final List<DoubleSupplier> signals = new ArrayList<>();
   private final List<Queue<Double>> queues = new ArrayList<>();
   private final List<Queue<Double>> timestampQueues = new ArrayList<>();
-  public static final ReadWriteLock lock = new ReentrantReadWriteLock();
 
   private final Notifier notifier;
 
@@ -49,12 +46,14 @@ class SparkOdometryThread {
    */
   public Queue<Double> registerSignal(DoubleSupplier signal) {
     Queue<Double> entry = new ArrayBlockingQueue<>(10);
-    lock.writeLock().lock();
+    Drive.lock.writeLock().lock();
 
-    signals.add(signal);
-    queues.add(entry);
-
-    lock.writeLock().unlock();
+    try {
+      signals.add(signal);
+      queues.add(entry);
+    } finally {
+      Drive.lock.writeLock().unlock();
+    }
     return entry;
   }
 
@@ -65,14 +64,17 @@ class SparkOdometryThread {
   }
 
   private void periodic() {
-    lock.writeLock().lock();
-    double timestamp = Timer.getFPGATimestamp(); // non-deterministic
-    for (int i = 0; i < signals.size(); i++) {
-      queues.get(i).offer(signals.get(i).getAsDouble());
+    Drive.lock.writeLock().lock();
+    try {
+      double timestamp = Timer.getFPGATimestamp(); // non-deterministic
+      for (int i = 0; i < signals.size(); i++) {
+        queues.get(i).offer(signals.get(i).getAsDouble());
+      }
+      for (int i = 0; i < timestampQueues.size(); i++) {
+        timestampQueues.get(i).offer(timestamp);
+      }
+    } finally {
+      Drive.lock.writeLock().unlock();
     }
-    for (int i = 0; i < timestampQueues.size(); i++) {
-      timestampQueues.get(i).offer(timestamp);
-    }
-    lock.writeLock().unlock();
   }
 }

--- a/src/main/java/org/sciborgs1155/robot/drive/SparkOdometryThread.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SparkOdometryThread.java
@@ -12,24 +12,23 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.DoubleSupplier;
 import org.sciborgs1155.robot.Constants;
 
-class OdometryThread {
+class SparkOdometryThread {
   private List<DoubleSupplier> signals = new ArrayList<>();
   private List<Queue<Double>> queues = new ArrayList<>();
-
   public static final ReadWriteLock lock = new ReentrantReadWriteLock();
 
   private final Notifier notifier;
 
-  private static OdometryThread instance = null;
+  private static SparkOdometryThread instance = null;
 
-  public static OdometryThread getInstance() {
+  public static SparkOdometryThread getInstance() {
     if (instance == null) {
-      instance = new OdometryThread();
+      instance = new SparkOdometryThread();
     }
     return instance;
   }
 
-  private OdometryThread() {
+  private SparkOdometryThread() {
     notifier = new Notifier(this::periodic);
     notifier.setName("odometry-thread");
   }
@@ -38,7 +37,7 @@ class OdometryThread {
     notifier.startPeriodic(Constants.ODOMETRY_PERIOD.in(Seconds));
   }
 
-  public Queue<Double> registerSignals(DoubleSupplier signal) {
+  public Queue<Double> registerSignal(DoubleSupplier signal) {
     Queue<Double> entry = new ArrayBlockingQueue<>(10);
     lock.writeLock().lock();
 

--- a/src/main/java/org/sciborgs1155/robot/drive/SwerveModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SwerveModule.java
@@ -85,6 +85,16 @@ public class SwerveModule implements Logged, AutoCloseable {
     return new SwerveModulePosition(hardware.drivePosition(), hardware.rotation());
   }
 
+  public SwerveModulePosition[] odometryData() {
+    SwerveModulePosition[] positions = new SwerveModulePosition[10];
+    // turn rotation into rotation2ds, and create swervemodule
+    var data = hardware.odometryData();
+    for (int i = 0; i < data.length; i++) {
+      positions[i] = new SwerveModulePosition(data[i][0], Rotation2d.fromRadians(data[i][2]));
+    }
+    return positions;
+  }
+
   /**
    * Updates controllers based on an optimized desired state and actuates the module accordingly.
    *

--- a/src/main/java/org/sciborgs1155/robot/drive/SwerveModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SwerveModule.java
@@ -88,10 +88,12 @@ public class SwerveModule implements Logged, AutoCloseable {
   /** Returns the list of positions of the module for the last tick, from a faster thread. */
   public SwerveModulePosition[] odometryData() {
     SwerveModulePosition[] positions = new SwerveModulePosition[10];
+    Drive.lock.readLock().lock();
     var data = hardware.odometryData();
     for (int i = 0; i < data.length; i++) {
       positions[i] = new SwerveModulePosition(data[0][i], Rotation2d.fromRadians(data[1][i]));
     }
+    Drive.lock.readLock().unlock();
     return positions;
   }
 

--- a/src/main/java/org/sciborgs1155/robot/drive/SwerveModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/SwerveModule.java
@@ -85,14 +85,19 @@ public class SwerveModule implements Logged, AutoCloseable {
     return new SwerveModulePosition(hardware.drivePosition(), hardware.rotation());
   }
 
+  /** Returns the list of positions of the module for the last tick, from a faster thread. */
   public SwerveModulePosition[] odometryData() {
     SwerveModulePosition[] positions = new SwerveModulePosition[10];
-    // turn rotation into rotation2ds, and create swervemodule
     var data = hardware.odometryData();
     for (int i = 0; i < data.length; i++) {
-      positions[i] = new SwerveModulePosition(data[i][0], Rotation2d.fromRadians(data[i][2]));
+      positions[i] = new SwerveModulePosition(data[0][i], Rotation2d.fromRadians(data[1][i]));
     }
     return positions;
+  }
+
+  /** Returns odometry-affiliated timestamps for pose estimation. */
+  public double[] timestamps() {
+    return hardware.odometryData()[2];
   }
 
   /**

--- a/src/main/java/org/sciborgs1155/robot/drive/TalonModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/TalonModule.java
@@ -1,6 +1,7 @@
 package org.sciborgs1155.robot.drive;
 
 import static edu.wpi.first.units.Units.*;
+import static org.sciborgs1155.robot.Constants.ODOMETRY_PERIOD;
 
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.hardware.TalonFX;
@@ -44,7 +45,7 @@ public class TalonModule implements ModuleIO {
     turnMotor.setIdleMode(IdleMode.kBrake);
     turnMotor.setSmartCurrentLimit((int) Turning.CURRENT_LIMIT.in(Amps));
 
-    driveMotor.getPosition().setUpdateFrequency(100);
+    driveMotor.getPosition().setUpdateFrequency(1.0 / ODOMETRY_PERIOD.in(Seconds));
     driveMotor.getVelocity().setUpdateFrequency(100);
 
     turnEncoder = turnMotor.getAbsoluteEncoder(Type.kDutyCycle);
@@ -71,6 +72,7 @@ public class TalonModule implements ModuleIO {
 
     talonThread = TalonOdometryThread.getInstance();
     position = talonThread.registerSignal(driveMotor.getPosition());
+
     timestamps = talonThread.makeTimestampQueue();
 
     turnMotor.burnFlash();

--- a/src/main/java/org/sciborgs1155/robot/drive/TalonModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/TalonModule.java
@@ -95,7 +95,7 @@ public class TalonModule implements ModuleIO {
   }
 
   @Override
-  public double[] odometryMeasurements() {
+  public double[][] odometrySignals() {
     // TODO Auto-generated method stub
     throw new UnsupportedOperationException("Unimplemented method 'odometryMeasurements'");
   }

--- a/src/main/java/org/sciborgs1155/robot/drive/TalonModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/TalonModule.java
@@ -93,4 +93,10 @@ public class TalonModule implements ModuleIO {
     turnMotor.close();
     driveMotor.close();
   }
+
+  @Override
+  public double[] odometryMeasurements() {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'odometryMeasurements'");
+  }
 }

--- a/src/main/java/org/sciborgs1155/robot/drive/TalonModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/TalonModule.java
@@ -108,14 +108,17 @@ public class TalonModule implements ModuleIO {
 
   @Override
   public double[][] odometryData() {
-    SparkOdometryThread.lock.readLock().lock();
-    double[][] data = {
-      position.stream().mapToDouble((Double d) -> d).toArray(),
-      rotation.stream().mapToDouble((Double d) -> d).toArray(),
-      timestamps.stream().mapToDouble((Double d) -> d).toArray()
-    };
-    SparkOdometryThread.lock.readLock().unlock();
-    return data;
+    Drive.lock.readLock().lock();
+    try {
+      double[][] data = {
+        position.stream().mapToDouble((Double d) -> d).toArray(),
+        rotation.stream().mapToDouble((Double d) -> d).toArray(),
+        timestamps.stream().mapToDouble((Double d) -> d).toArray()
+      };
+      return data;
+    } finally {
+      Drive.lock.readLock().unlock();
+    }
   }
 
   @Override

--- a/src/main/java/org/sciborgs1155/robot/drive/TalonModule.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/TalonModule.java
@@ -24,10 +24,6 @@ public class TalonModule implements ModuleIO {
   private final TalonFX driveMotor;
   private final CANSparkMax turnMotor;
 
-  private final Queue<Double> position;
-  private final Queue<Double> velocity;
-  private final Queue<Double> rotation;
-
   private final SparkAbsoluteEncoder turnEncoder;
 
   private final Rotation2d angularOffset;
@@ -35,6 +31,10 @@ public class TalonModule implements ModuleIO {
 
   private final SparkOdometryThread sparkThread;
   private final TalonOdometryThread talonThread;
+
+  private final Queue<Double> position;
+  private final Queue<Double> rotation;
+  private final Queue<Double> timestamps;
 
   public TalonModule(int drivePort, int turnPort, Rotation2d angularOffset) {
     driveMotor = new TalonFX(drivePort);
@@ -71,7 +71,7 @@ public class TalonModule implements ModuleIO {
 
     talonThread = TalonOdometryThread.getInstance();
     position = talonThread.registerSignal(driveMotor.getPosition());
-    velocity = talonThread.registerSignal(driveMotor.getVelocity());
+    timestamps = talonThread.makeTimestampQueue();
 
     turnMotor.burnFlash();
     this.angularOffset = angularOffset;
@@ -111,8 +111,8 @@ public class TalonModule implements ModuleIO {
     SparkOdometryThread.lock.readLock().lock();
     double[][] data = {
       position.stream().mapToDouble((Double d) -> d).toArray(),
-      velocity.stream().mapToDouble((Double d) -> d).toArray(),
-      rotation.stream().mapToDouble((Double d) -> d).toArray()
+      rotation.stream().mapToDouble((Double d) -> d).toArray(),
+      timestamps.stream().mapToDouble((Double d) -> d).toArray()
     };
     SparkOdometryThread.lock.readLock().unlock();
     return data;

--- a/src/main/java/org/sciborgs1155/robot/drive/TalonOdometryThread.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/TalonOdometryThread.java
@@ -1,0 +1,62 @@
+package org.sciborgs1155.robot.drive;
+
+import static edu.wpi.first.units.Units.Seconds;
+
+import com.ctre.phoenix6.BaseStatusSignal;
+import com.ctre.phoenix6.StatusSignal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.sciborgs1155.robot.Constants;
+
+class TalonOdometryThread extends Thread {
+  public static final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+  private BaseStatusSignal[] signals = new BaseStatusSignal[0];
+  private final List<Queue<Double>> queues = new ArrayList<>();
+
+  private static TalonOdometryThread instance = null;
+
+  public static TalonOdometryThread getInstance() {
+    if (instance == null) {
+      instance = new TalonOdometryThread();
+    }
+    return instance;
+  }
+
+  @Override
+  public void start() {
+    super.start();
+  }
+
+  public Queue<Double> registerSignal(StatusSignal<Double> signal) {
+    Queue<Double> queue = new ArrayBlockingQueue<>(20);
+    lock.writeLock().lock();
+    try {
+      BaseStatusSignal[] newSignals = new BaseStatusSignal[signals.length + 1];
+      System.arraycopy(signals, 0, newSignals, 0, signals.length);
+      newSignals[signals.length] = signal;
+      signals = newSignals;
+      queues.add(queue);
+    } finally {
+      lock.writeLock().unlock();
+    }
+    return queue;
+  }
+
+  @Override
+  public void run() {
+    while (true) {
+      BaseStatusSignal.waitForAll(2.0 / Constants.ODOMETRY_PERIOD.in(Seconds), signals);
+
+      lock.writeLock().lock();
+      for (int i = 0; i < signals.length; i++) {
+        queues.get(i).offer(signals[i].getValueAsDouble());
+      }
+      lock.writeLock().unlock();
+    }
+  }
+}

--- a/src/main/java/org/sciborgs1155/robot/drive/TalonOdometryThread.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/TalonOdometryThread.java
@@ -60,7 +60,7 @@ class TalonOdometryThread extends Thread {
   @Override
   public void run() {
     while (true) {
-      BaseStatusSignal.waitForAll(2.0 / Constants.ODOMETRY_PERIOD.in(Seconds), signals);
+      BaseStatusSignal.waitForAll(2.0 * Constants.ODOMETRY_PERIOD.in(Seconds), signals);
 
       Drive.lock.writeLock().lock();
 

--- a/src/main/java/org/sciborgs1155/robot/drive/TalonOdometryThread.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/TalonOdometryThread.java
@@ -8,13 +8,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.sciborgs1155.robot.Constants;
 
 class TalonOdometryThread extends Thread {
-  public static final ReadWriteLock lock = new ReentrantReadWriteLock();
-
   private BaseStatusSignal[] signals = new BaseStatusSignal[0];
   private final List<Queue<Double>> queues = new ArrayList<>();
   private final List<Queue<Double>> timestampQueues = new ArrayList<>();
@@ -37,7 +33,7 @@ class TalonOdometryThread extends Thread {
 
   public Queue<Double> registerSignal(StatusSignal<Double> signal) {
     Queue<Double> queue = new ArrayBlockingQueue<>(20);
-    lock.writeLock().lock();
+    Drive.lock.writeLock().lock();
     try {
       BaseStatusSignal[] newSignals = new BaseStatusSignal[signals.length + 1];
       System.arraycopy(signals, 0, newSignals, 0, signals.length);
@@ -45,14 +41,19 @@ class TalonOdometryThread extends Thread {
       signals = newSignals;
       queues.add(queue);
     } finally {
-      lock.writeLock().unlock();
+      Drive.lock.writeLock().unlock();
     }
     return queue;
   }
 
   public Queue<Double> makeTimestampQueue() {
     Queue<Double> queue = new ArrayBlockingQueue<>(20);
-    timestampQueues.add(queue);
+    Drive.lock.writeLock().lock();
+    try {
+      timestampQueues.add(queue);
+    } finally {
+      Drive.lock.writeLock().lock();
+    }
     return queue;
   }
 
@@ -60,25 +61,28 @@ class TalonOdometryThread extends Thread {
   public void run() {
     while (true) {
       BaseStatusSignal.waitForAll(2.0 / Constants.ODOMETRY_PERIOD.in(Seconds), signals);
-      double timestamp = signals[0].getTimestamp().getTime(); // should all be measured together
 
-      lock.writeLock().lock();
+      Drive.lock.writeLock().lock();
 
-      double totalLatency = 0.0;
-      for (BaseStatusSignal signal : signals) {
-        totalLatency += signal.getTimestamp().getLatency();
-      }
-      if (signals.length > 0) {
-        timestamp -= totalLatency / signals.length;
-      }
-      for (int i = 0; i < signals.length; i++) {
-        queues.get(i).offer(signals[i].getValueAsDouble());
-      }
-      for (int i = 0; i < timestampQueues.size(); i++) {
-        timestampQueues.get(i).offer(timestamp);
-      }
+      try {
+        double timestamp = signals[0].getTimestamp().getTime(); // should all be measured together
 
-      lock.writeLock().unlock();
+        double totalLatency = 0.0;
+        for (BaseStatusSignal signal : signals) {
+          totalLatency += signal.getTimestamp().getLatency();
+        }
+        if (signals.length > 0) {
+          timestamp -= totalLatency / signals.length;
+        }
+        for (int i = 0; i < signals.length; i++) {
+          queues.get(i).offer(signals[i].getValueAsDouble());
+        }
+        for (int i = 0; i < timestampQueues.size(); i++) {
+          timestampQueues.get(i).offer(timestamp);
+        }
+      } finally {
+        Drive.lock.writeLock().unlock();
+      }
     }
   }
 }


### PR DESCRIPTION
Run sensor-grabbing on a separate higher-frequency thread to receive more updated and accurate odometry data. Should work with any configuration of CAN FD Sparks and Talons, given the correct threads are used for each. 