### PR TITLE
auto-feeding

### DIFF
--- a/simgui-ds.json
+++ b/simgui-ds.json
@@ -1,12 +1,7 @@
 {
-  "FMS": {
+  "Keyboard 0 Settings": {
     "window": {
-      "visible": false
-    }
-  },
-  "Joysticks": {
-    "window": {
-      "visible": false
+      "visible": true
     }
   },
   "System Joysticks": {

--- a/simgui.json
+++ b/simgui.json
@@ -1,6 +1,9 @@
 {
   "HALProvider": {
     "Addressable LEDs": {
+      "0": {
+        "serpentine": true
+      },
       "window": {
         "visible": true
       }
@@ -100,6 +103,11 @@
           "visible": true
         }
       },
+      "/Robot/pivot/positionVisualizer": {
+        "window": {
+          "visible": true
+        }
+      },
       "/SmartDashboard/VisionSystemSim-main/Sim Field": {
         "bottom": 1476,
         "height": 8.210550308227539,
@@ -160,23 +168,21 @@
             "open": true
           }
         },
-        "feeder": {
-          "open": true
-        },
-        "intake": {
-          "open": true
-        },
         "open": true,
         "pivot": {
+          "Rotation3d##v_/Robot/pivot/rotation": {
+            "open": true
+          },
           "hardware": {
             "open": true
           },
+          "open": true,
           "pid": {
             "open": true
+          },
+          "positionVisualizer": {
+            "open": true
           }
-        },
-        "shooter": {
-          "open": true
         }
       }
     }
@@ -186,8 +192,5 @@
       "open": true
     },
     "visible": true
-  },
-  "NetworkTables View": {
-    "visible": false
   }
 }

--- a/src/main/java/org/sciborgs1155/robot/Constants.java
+++ b/src/main/java/org/sciborgs1155/robot/Constants.java
@@ -141,6 +141,10 @@ public class Constants {
       return alliance() == Alliance.Blue ? BLUE_AMP : RED_AMP;
     }
 
+    public static Translation2d feedTarget() {
+      return amp().plus(new Translation2d(Inches.of(0), Inches.of(-24)));
+    }
+
     /** Returns whether the provided position is within the boundaries of the field. */
     public static boolean inField(Pose3d pose) {
       return (pose.getX() > 0

--- a/src/main/java/org/sciborgs1155/robot/Robot.java
+++ b/src/main/java/org/sciborgs1155/robot/Robot.java
@@ -148,13 +148,14 @@ public class Robot extends CommandRobot implements Logged {
     } else {
       DriverStation.silenceJoystickConnectionWarning(true);
       addPeriodic(() -> vision.simulationPeriodic(drive.pose()), PERIOD.in(Seconds));
-      NoteVisualizer.setSuppliers(
-          drive::pose,
-          shooting::shooterPose,
-          drive::getFieldRelativeChassisSpeeds,
-          shooter::tangentialVelocity);
-      NoteVisualizer.startPublishing();
     }
+
+    NoteVisualizer.setSuppliers(
+        drive::pose,
+        shooting::shooterPose,
+        drive::getFieldRelativeChassisSpeeds,
+        shooter::tangentialVelocity);
+    NoteVisualizer.startPublishing();
   }
 
   /** Configures subsystem default commands & trigger -> command bindings. */
@@ -269,7 +270,7 @@ public class Robot extends CommandRobot implements Logged {
                 .deadlineWith(Commands.idle(shooter)))
         .toggleOnTrue(led.raindrop());
 
-    operator.y().whileTrue(shooting.feedToAmp(x, y));
+    driver.y().whileTrue(shooting.feedToAmp(x, y));
 
     // operator manual shoot (povDown)
     operator.povDown().whileTrue(shooting.shoot(RadiansPerSecond.of(350))).whileTrue(led.rainbow());

--- a/src/main/java/org/sciborgs1155/robot/Robot.java
+++ b/src/main/java/org/sciborgs1155/robot/Robot.java
@@ -269,7 +269,7 @@ public class Robot extends CommandRobot implements Logged {
                 .deadlineWith(Commands.idle(shooter)))
         .toggleOnTrue(led.raindrop());
 
-    operator.y().onTrue(shooting.feedToAmp(x, y));
+    operator.y().whileTrue(shooting.feedToAmp(x, y));
 
     // operator manual shoot (povDown)
     operator.povDown().whileTrue(shooting.shoot(RadiansPerSecond.of(350))).whileTrue(led.rainbow());

--- a/src/main/java/org/sciborgs1155/robot/Robot.java
+++ b/src/main/java/org/sciborgs1155/robot/Robot.java
@@ -7,6 +7,7 @@ import static edu.wpi.first.units.Units.Second;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.wpilibj2.command.button.RobotModeTriggers.*;
 import static org.sciborgs1155.robot.Constants.DEADBAND;
+import static org.sciborgs1155.robot.Constants.Field.feedTarget;
 import static org.sciborgs1155.robot.Constants.PERIOD;
 import static org.sciborgs1155.robot.drive.DriveConstants.MAX_ANGULAR_ACCEL;
 import static org.sciborgs1155.robot.drive.DriveConstants.MAX_SPEED;
@@ -16,6 +17,8 @@ import static org.sciborgs1155.robot.pivot.PivotConstants.AMP_ANGLE;
 import static org.sciborgs1155.robot.pivot.PivotConstants.STARTING_ANGLE;
 import static org.sciborgs1155.robot.shooter.ShooterConstants.AMP_VELOCITY;
 
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.GenericHID.RumbleType;
@@ -116,6 +119,9 @@ public class Robot extends CommandRobot implements Logged {
     addPeriodic(
         () -> log("dist", Shooting.translationToSpeaker(drive.pose().getTranslation()).getNorm()),
         kDefaultPeriod);
+
+    addPeriodic(
+        () -> log("feedTarget", new Pose2d(feedTarget(), new Rotation2d())), kDefaultPeriod);
 
     SmartDashboard.putData(CommandScheduler.getInstance());
     // Log PDH
@@ -262,6 +268,8 @@ public class Robot extends CommandRobot implements Logged {
                     InputStream.of(operator::getLeftY).negate().deadband(Constants.DEADBAND, 1))
                 .deadlineWith(Commands.idle(shooter)))
         .toggleOnTrue(led.raindrop());
+
+    operator.y().onTrue(shooting.feedToAmp());
 
     // operator manual shoot (povDown)
     operator.povDown().whileTrue(shooting.shoot(RadiansPerSecond.of(350))).whileTrue(led.rainbow());

--- a/src/main/java/org/sciborgs1155/robot/Robot.java
+++ b/src/main/java/org/sciborgs1155/robot/Robot.java
@@ -269,7 +269,7 @@ public class Robot extends CommandRobot implements Logged {
                 .deadlineWith(Commands.idle(shooter)))
         .toggleOnTrue(led.raindrop());
 
-    operator.y().onTrue(shooting.feedToAmp());
+    operator.y().onTrue(shooting.feedToAmp(x, y));
 
     // operator manual shoot (povDown)
     operator.povDown().whileTrue(shooting.shoot(RadiansPerSecond.of(350))).whileTrue(led.rainbow());

--- a/src/main/java/org/sciborgs1155/robot/commands/NoteVisualizer.java
+++ b/src/main/java/org/sciborgs1155/robot/commands/NoteVisualizer.java
@@ -146,7 +146,7 @@ public class NoteVisualizer implements Logged {
                 },
                 Set.of()))
         // .unless(() -> !carryingNote)
-        .unless(Robot::isReal)
+        // .unless(Robot::isReal)
         .ignoringDisable(true);
   }
 

--- a/src/main/java/org/sciborgs1155/robot/commands/Shooting.java
+++ b/src/main/java/org/sciborgs1155/robot/commands/Shooting.java
@@ -56,7 +56,7 @@ public class Shooting implements Logged {
    */
   public static final DoubleEntry siggysConstant = Tuning.entry("/Robot/Siggy's Constant", 4.42);
 
-  public static final DoubleEntry ethansConstant = Tuning.entry("/Robot/Ethan's Constant", 3.7);
+  public static final DoubleEntry ethansConstant = Tuning.entry("/Robot/Ethan's Constant", 3.2);
 
   public static final Measure<Distance> MAX_DISTANCE = Meters.of(5.0);
 

--- a/src/main/java/org/sciborgs1155/robot/commands/Shooting.java
+++ b/src/main/java/org/sciborgs1155/robot/commands/Shooting.java
@@ -56,7 +56,7 @@ public class Shooting implements Logged {
    */
   public static final DoubleEntry siggysConstant = Tuning.entry("/Robot/Siggy's Constant", 4.42);
 
-  public static final DoubleEntry ethansConstant = Tuning.entry("/Robot/Ethan's Constant", 4.42);
+  public static final DoubleEntry ethansConstant = Tuning.entry("/Robot/Ethan's Constant", 3.7);
 
   public static final Measure<Distance> MAX_DISTANCE = Meters.of(5.0);
 

--- a/src/main/java/org/sciborgs1155/robot/drive/DriveConstants.java
+++ b/src/main/java/org/sciborgs1155/robot/drive/DriveConstants.java
@@ -86,6 +86,8 @@ public final class DriveConstants {
       public static final Measure<Distance> POSITION_FACTOR = CIRCUMFERENCE.times(GEARING);
       public static final Measure<Velocity<Distance>> VELOCITY_FACTOR = POSITION_FACTOR.per(Minute);
 
+      public static final Measure<Velocity<Distance>> VELOCITY_TOLERANCE = MetersPerSecond.of(.1);
+
       public static final Measure<Current> CURRENT_LIMIT = Amps.of(50);
 
       public static final class PID {

--- a/src/main/java/org/sciborgs1155/robot/intake/IntakeConstants.java
+++ b/src/main/java/org/sciborgs1155/robot/intake/IntakeConstants.java
@@ -8,6 +8,7 @@ import edu.wpi.first.units.Time;
 
 public final class IntakeConstants {
   public static final double INTAKE_SPEED = 0.8;
+
   public static final Measure<Current> CURRENT_LIMIT = Amps.of(50);
   public static final Measure<Time> RAMP_TIME = Milliseconds.of(50);
   public static final Measure<Time> DEBOUNCE_TIME = Seconds.of(0);


### PR DESCRIPTION
PR for task "Auto Feed"

Shoots at target 2 feet in front of the amp at z=0. The shot velocity is calculated in terms of the pitch (math can be found [here](https://www.desmos.com/calculator/l1scr8n3nz)). Pivot angle can be changed beforehand through operator manual pivot, and it will hold that angle for the duration of the shot. 

Since the note is shot high and likely changes orientation in its arc, the note will almost certainly not land where it is modeled in code. Testing that is a very good idea.

I've also added ethan's constant so we can change that to account for disturbances (assuming that we would want to account for different disturbances in the feeding vs shooting code). You may wish to change the name.

![image](https://github.com/user-attachments/assets/ef894932-065d-4423-af0a-b9553e15b4fc)

Also supports feeding while driving

https://github.com/user-attachments/assets/6555afab-ca61-4bb7-b928-1315e257381c

